### PR TITLE
XP-3935 Do not re-draw the VWO widget on changing the details panel size

### DIFF
--- a/src/main/resources/admin/widgets/ga-report/ga-report.xml
+++ b/src/main/resources/admin/widgets/ga-report/ga-report.xml
@@ -4,4 +4,7 @@
   <interfaces>
     <interface>com.enonic.xp.content-manager.context-widget</interface>
   </interfaces>
+  <config>
+    <property name="render-on-resize" value="true" />
+  </config>
 </widget>


### PR DESCRIPTION
- Added "render-on-resize" config entry that forces widget to re-render on each resize
